### PR TITLE
Ported to OSX

### DIFF
--- a/code/_compile_zkbpp.sh
+++ b/code/_compile_zkbpp.sh
@@ -1,1 +1,2 @@
-g++ -std=c++0x -g -O2 -march=native -mtune=native main.cpp ZKBPP.cpp CircuitContainer.cpp BigIntLib.cpp -o zkbpp_test -lcrypto -lm
+CFLAGS+="-I/usr/local/Cellar/openssl/1.0.2q/include -L/usr/local/Cellar/openssl/1.0.2q/lib/"
+${CXX} -std=c++0x -g -O2 -march=native -mtune=native ${CFLAGS} main.cpp affinity_osx.cpp ZKBPP.cpp CircuitContainer.cpp BigIntLib.cpp -o zkbpp_test -lcrypto -lm

--- a/code/affinity_osx.cpp
+++ b/code/affinity_osx.cpp
@@ -1,0 +1,45 @@
+#include "common.h"
+
+#ifdef __APPLE__
+
+int sched_getaffinity(pid_t pid, size_t cpu_size, cpu_set_t *cpu_set)
+ {
+   int32_t core_count = 0;
+   size_t  len = sizeof(core_count);
+   int ret = sysctlbyname(SYSCTL_CORE_COUNT, &core_count, &len, 0, 0);
+   if (ret) {
+     printf("error while get core count %d\n", ret);
+     return -1;
+   }
+   cpu_set->count = 0;
+   for (int i = 0; i < core_count; i++) {
+     cpu_set->count |= (1 << i);
+   }
+ 
+   return 0;
+ }
+ 
+int pthread_setaffinity_np(pthread_t thread, size_t cpu_size,
+                            cpu_set_t *cpu_set)
+{
+   thread_port_t mach_thread;
+   int core = 0;
+ 
+   for (core = 0; core < 8 * cpu_size; core++) {
+     if (CPU_ISSET(core, cpu_set)) break;
+   }
+   printf("binding to core %d\n", core);
+   thread_affinity_policy_data_t policy = { core };
+   mach_thread = pthread_mach_thread_np(thread);
+   thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY,
+                     (thread_policy_t)&policy, 1);
+   return 0;
+}
+ 
+int sched_setaffinity(pthread_t thread, size_t cpu_size, cpu_set_t *cpu_set)
+{
+     return pthread_setaffinity_np(thread, cpu_size, cpu_set);
+}
+
+#endif
+

--- a/code/common.h
+++ b/code/common.h
@@ -129,4 +129,35 @@ typedef struct {
 // Forward declarations
 class Circuit;
 
+// OSX definitions
+#ifdef __APPLE__
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+#include <mach/mach_init.h>
+#include <mach/thread_act.h>
+#include <mach/mach_port.h>
+
+#define SYSCTL_CORE_COUNT   "machdep.cpu.core_count"
+
+typedef struct cpu_set {
+  uint32_t    count;
+} cpu_set_t;
+
+static inline void
+CPU_ZERO(cpu_set_t *cs) { cs->count = 0; }
+
+static inline void
+CPU_SET(int num, cpu_set_t *cs) { cs->count |= (1 << num); }
+
+static inline int
+CPU_ISSET(int num, cpu_set_t *cs) { return (cs->count & (1 << num)); }
+
+extern int sched_getaffinity      (pid_t        pid, size_t cpu_size, cpu_set_t *cpu_set);
+extern int pthread_setaffinity_np (pthread_t thread, size_t cpu_size, cpu_set_t *cpu_set);
+extern int sched_setaffinity      (pthread_t thread, size_t cpu_size, cpu_set_t *cpu_set);
+
+#endif // APPLE
+
 #endif // COMMON_H


### PR DESCRIPTION
Dear Sir,

I would like to offer my changes that makes possible to build **gzkbpp** on OSX with GCC compilers set.

Here are tests results:
```

code [master●●] % ./zkbpp_test 256 1 0 1 1
Starting
binding to core 0
Direct output: f372587a74c2ea587a56df4e174a74529dbf834092c0d1758f047dbd15e38496
[ZKBPP] challenge: 
68 67 9c f6 f8 32 0b 0f a1 d8 49 d1 cc fc 5a 9c eb aa 80 5c 38 6b eb d5 67 b3 36 05 f7 ac 12 5c
...

[ZKBPP] challenge': 
68 67 9c f6 f8 32 0b 0f a1 d8 49 d1 cc fc 5a 9c eb aa 80 5c 38 6b eb d5 67 b3 36 05 f7 ac 12 5c

Direct output: aa64ddef2001317f036ede5208a6af025470472ce1a489a1a02abec5afbdd220
Direct output: 5a5769f38b43e8e93d2b23284237d02b8ce15ef76800115391ed5647ac24a855
Direct output: e9c5ff60ab0e5f0faa54c38ed92e7d50a8c2d935bbf55a02bfdbfb6e799bf243
Direct output: d104e8ca20e688e49fbc3a4120edce6cff2ea1527ea7c7e798e9c92357d56ee6
Direct output: ccc8340daf0829537b04a667106b05c14dacd98bf5874729fe97b45c64f44b63
Direct output: eddb7b71992c029c821259422c17916684087256a87b60539c7ceb2907414170
Direct output: 4ad9adc046539962a711ad50ad9a82575c858af161bb50d64dcd8f321da4918a
Direct output: 0f58924e2cdd6103a77a1427cf80378937db17f948bca592775a1a3d50c1acbe
Direct output: ee2ddcf56b45d04c823fc399e075b43f1c41ad18d9a436e5c6833fae26d0c37e
Direct output: 581a543f8c0e04588050dd51175ccb27ae628328a58177868899acb5ff22a885
Direct output: beace5d5c23cdb14c2f6c28030271b47cb93f7339e55f491aed0a31f8230f4e5
Direct output: 49d4025d1818730e0a027436756ca6ff71917b01292e7c30d6bca28ef2134ea3
Direct output: c3644750ff518d414e49bf45e7f13e33bcf82a4c72315bbde5f428bd5f7bd9dd
Direct output: 47b10b86813becc45953accb83c1cd8bbd15ec7d704eda0caf013a96264181af
Direct output: 79865ca5f8d3c8da552f422295311367ffcf44d18548b1f9c841f3563b846f44
Direct output: ff30bfaa67347139a160a19c8f00969b04b216481dc494617efb9c8ccea7272d
Direct output: 9130adcc97f37518afcefa6c30b176357b58f65d90417cf7993702f56bbe7f60
Direct output: a9636c72835027672d21ba1a83864871289e341a0efb3efd685fafa42c3340bc
Direct output: 85d3c73d122bd9f264cdeb1fc9b6afc5f27fa7280562f5c8cf16936e778c422d
Direct output: b224af9059b8659629304228c2b6d4cad74c8b2714dd754ee7b0ba2a143c96ad
Direct output: 6399eb7f1de94a75395db387f71ce46979186afce15b0d21a31af158286b61dd
Direct output: ca50064f70a45f4fb665280718737179590d3623887f99f6598386417690d035
Direct output: 717a66ac833a0b03ce097a648b8189444458d961fbe5157e04551da1019d68cb
Direct output: 2e0004af8da480dddd7591fc4d0d75602d4763003282e4b788300adb87bb8d37
Direct output: e1d364f66fa8e47c0ea933b419c21c0e352f40dec1b015093a136e4b2458a645
Direct output: 676229c2c4e1574c04a43094691f1587bf9a749624374e42462859c32ccb0cbe
Direct output: 134a4b4ec9249c34bd944646d771dfc461afbf6f08009d85b0461cee5409e5bf
Direct output: ac30dbe1ae51298047380b6e6587501c630160036e352734f219990d36bdbe65
Direct output: efbb57d99496d4af1078efda1e02b10ed20908aad1a725e1e30e4dd5065b0197
Direct output: c4c09e3de799165f630befbbc11e3064e515d6e545611d24603a7e3646478be9
Direct output: 6fe551105734537c6415dd3bc5a8b869dc3b1fdd9a3b0a5a073cf7508a4cc563
Direct output: b149748ea24402ffa4ba789d811292ecffa4c603a278e5e71cddc5c3119b650b
Direct output: 0e803b1f17fc01410930527bc759917c359404624f7212e7eb4502fe2029ab13
Direct output: d41a502a43691eddfde4a91007428746933f26b6301d4c99a4a41a2abd504721
Direct output: baa1249d9cd787fcb3fb178364d64eaf422885a628e5c6914eedd8145a70ad56
Direct output: 1dedd957df239e6a4c46ab9846ee37e2dcd662c290bd9dedce3f05f791b2456a
Direct output: 5a8e33d80f44a2724b85010217f0a91e5ab1541f41e355fce4f75a62a59cad65
Direct output: 50de3782dc13646a61d0f384e31178c603dcb0e7f188f4684a76d56cbdcad42c
Direct output: 591bcf4b495a23abda03266ffa8a92b6192cf0f79fac7ab2c666dfc07570026e
Direct output: 68622c5043fb2916b3186309c84e6ea7a796b34cd75c04b1f8b90a64210596aa
Direct output: 41e19aea8b0e165b7ee48c19a0f5f899129da8bfe8c988bb89f08445c169f598
Direct output: e1abec2a547da9c9a3e6dd05a5068cae2cad0e51e9b8b8352e9189e9eb67793b
Direct output: 916fa3b178e6767f0beb2f74350db980b51c5751a05e0e22c702e1c6cb68e1a9
Direct output: 2185626f1d91409d2cf32ef9b4c0e721368407d5b9c1d76ca8dd3f8a67b0b26f
Direct output: f280893919a98445d861261efcdeac48f832c72fad1d969bf4ad87c843d9f3a6
Direct output: 582eeff65c726ab21816c80398d817056ee17e68ed6aa8b8358190aa9d8cedee
Direct output: 84cc4565c6c0487f5c6a4f79c7a9a36e739e318901d7b5a0b89d67d75f86670e
Direct output: 5fb62bcf4740132753a94de1ba9db57135329a34f89039d41fce92379c3242ed
Direct output: ecadef26018f5000f034a044f9bdfbb832aabcc9ca252173e5a981d0f9bfbb03
Direct output: 029daa988dc396a137348da2907a3af6f4c4a0d5051facda9e10ab92adeec57b
--- CONFIGURATION ---
Number of test runs: 50
--- CIRCUIT ---
Field type: Prime field
Field size (bits): 256
Value size (bytes): 32
Key size (bytes): 32
Number of branches: 1
Number of cipher rounds: 162
Number of cipher MUL gates: 326
[Cipher] Cycles per byte: 11987
[Cipher] Average time for direct call: 0.17156 ms
--- TIME ---
Average time for gensign: 1.45622 ms
Average time for sign: 361.074 ms
Average time for sign (total): 362.531 ms
Average time for genverify: 0.60214 ms
Average time for verify: 189.786 ms
Average time for verify (total): 190.388 ms
Average time for circuit sign: 0.69394 ms
Average time for circuit verify: 0.34372 ms
Average time for all circuits sign: 303.946 ms
Average time for all circuits verify: 150.549 ms
--- ZKB++ ---
Number of ZKB++ iterations: 438
View size: 10432 bytes (83456 bits)
Expected signature size: ~4512 KB
Result: ACCEPT
& \((256, 1, 162)\) & \(1.46\) ms & \(362.53\) ms & \(0.60\) ms & \(190.39\) ms & \(83456\) bits & \(\approx 4512\) KB \\ \cline{2-8}
["MiMC-(256, 1, 162)", 362.53, 190.39, 4512]
```